### PR TITLE
Add explicit NDK version to gradle build config

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 29
-    ndkVersion "21.1.6352462"
+    ndkVersion "21.4.7075529"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Seems to be a common issue with GitHub Actions + Flutter: https://stackoverflow.com/questions/61146248/github-actions-flutter-ci-error-no-version-of-ndk-matched